### PR TITLE
Add star projector and air purifier aux switches, fix HA 2026 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Creates an air purifier with air quality monitoring.
   - Filter Life Sensor
   - PM2.5 Sensor
   - VOC Sensor
+  - Child Lock Switch
+  - Display On/Off Switch
   - Status Sensor
 
 ### Garage Door
@@ -158,6 +160,18 @@ Creates a security system from multiple sensors and controls.
 - Optional:
   - Security Sensors (multiple)
   - Siren Control
+  - Status Sensor
+
+### Star Projector
+
+Combines a master switch, rotation fan, and laser/background lights into a single star projector device. Useful for child night lights such as Tuya/local-tuya based projectors that expose multiple entities (e.g. `switch.star_projector_master`, `fan.star_projector_rotation`, `light.star_projector_laser`, `light.star_projector_background`).
+
+- Required:
+  - Power Switch (master switch)
+- Optional:
+  - Laser Light (light entity)
+  - Background/Nebula Light (light entity)
+  - Rotation Fan (fan entity)
   - Status Sensor
 
 ## HomeKit Integration

--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS: Final = [
     Platform.SELECT,
     Platform.BINARY_SENSOR,
     Platform.LIGHT,
+    Platform.FAN,
 ]
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/config_flow.py
+++ b/config_flow.py
@@ -41,6 +41,11 @@ from .const import (
     CONF_ALARM_STATE,
     CONF_SENSORS,
     CONF_SIREN,
+    CONF_LASER_LIGHT,
+    CONF_BACKGROUND_LIGHT,
+    CONF_ROTATION_FAN,
+    CONF_CHILD_LOCK,
+    CONF_DISPLAY_SWITCH,
     DEVICE_TYPES,
     DEFAULT_NAME,
 )
@@ -191,6 +196,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_VOC): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor")
                 ),
+                vol.Optional(CONF_CHILD_LOCK): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="switch")
+                ),
+                vol.Optional(CONF_DISPLAY_SWITCH): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="switch")
+                ),
             },
             "garage_door": {
                 vol.Required(CONF_DOOR_POSITION): selector.EntitySelector(
@@ -218,6 +229,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ),
                 vol.Optional(CONF_SIREN): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="switch")
+                ),
+            },
+            "star_projector": {
+                vol.Optional(CONF_LASER_LIGHT): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="light")
+                ),
+                vol.Optional(CONF_BACKGROUND_LIGHT): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="light")
+                ),
+                vol.Optional(CONF_ROTATION_FAN): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="fan")
                 ),
             },
         }

--- a/const.py
+++ b/const.py
@@ -40,7 +40,8 @@ DEVICE_TYPES = {
     "humidifier": "A humidifier with humidity sensing and control",
     "air_purifier": "An air purifier with air quality monitoring",
     "garage_door": "A garage door with multiple sensors",
-    "security_system": "A security system with multiple sensors and controls"
+    "security_system": "A security system with multiple sensors and controls",
+    "star_projector": "A star projector with master switch, rotation fan, and laser/background lights"
 }
 
 # Configuration keys for all device types
@@ -79,6 +80,8 @@ CONF_AIR_QUALITY = "air_quality"
 CONF_FILTER_LIFE = "filter_life"
 CONF_PM25 = "pm25"
 CONF_VOC = "voc"
+CONF_CHILD_LOCK = "child_lock"
+CONF_DISPLAY_SWITCH = "display_switch"
 
 # Garage door related configs
 CONF_DOOR_POSITION = "door_position"
@@ -91,6 +94,11 @@ CONF_ALARM_STATE = "alarm_state"
 CONF_SENSORS = "sensors"  # List of security sensors
 CONF_SIREN = "siren"
 CONF_KEYPAD = "keypad"
+
+# Star projector related configs
+CONF_LASER_LIGHT = "laser_light"
+CONF_BACKGROUND_LIGHT = "background_light"
+CONF_ROTATION_FAN = "rotation_fan"
 
 # Default values
 DEFAULT_NAME = "Aggregated Device"

--- a/entity.py
+++ b/entity.py
@@ -5,22 +5,14 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.select import SelectEntity
 from homeassistant.components.fan import FanEntity, FanEntityFeature
-from homeassistant.const import (
-    ATTR_NAME,
-    STATE_ON,
-    STATE_OFF,
-    UnitOfTemperature,
-)
+from homeassistant.const import STATE_ON, UnitOfTemperature
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.event import async_track_state_change_event
 
-from .const import DOMAIN, CONF_NAME, CONF_DEVICE_TYPE
+from .const import DOMAIN, CONF_NAME
 from .homekit_type import (
     CHAR_CURRENT_TEMPERATURE,
-    CHAR_TARGET_TEMPERATURE,
     CHAR_HEATING_COOLING_CURRENT,
 )
 

--- a/entity.py
+++ b/entity.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.components.select import SelectEntity
+from homeassistant.components.fan import FanEntity, FanEntityFeature
 from homeassistant.const import (
     ATTR_NAME,
     STATE_ON,
     STATE_OFF,
     UnitOfTemperature,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
-from homeassistant.helpers.event import async_track_state_change
+from homeassistant.helpers.event import async_track_state_change_event
 
 from .const import DOMAIN, CONF_NAME, CONF_DEVICE_TYPE
 from .homekit_type import (
@@ -49,16 +50,17 @@ class HomeKitDeviceEntity:
 
     async def async_added_to_hass(self) -> None:
         """Run when entity is added to register update signal handler."""
-        async def _update_from_source(entity_id, old_state, new_state):
+        async def _handle_state_change(event: Event[EventStateChangedData]) -> None:
+            new_state = event.data["new_state"]
             if new_state is None:
                 return
             await self.async_update_from_source(new_state)
 
         self.async_on_remove(
-            async_track_state_change(
+            async_track_state_change_event(
                 self.hass,
-                self._source_entity,
-                _update_from_source
+                [self._source_entity],
+                _handle_state_change,
             )
         )
 
@@ -150,4 +152,46 @@ class HomeKitDeviceSelect(HomeKitDeviceEntity, SelectEntity):
             self._attr_current_option = "On" if state.state != "Off" else "Off"
         else:
             self._attr_current_option = state.state
+        self.async_write_ha_state()
+
+class HomeKitDeviceFan(HomeKitDeviceEntity, FanEntity):
+    """Representation of a HomeKit Device fan."""
+
+    _attr_supported_features = (
+        FanEntityFeature.SET_SPEED
+        | FanEntityFeature.TURN_ON
+        | FanEntityFeature.TURN_OFF
+    )
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs,
+    ) -> None:
+        """Turn the fan on."""
+        data: dict[str, object] = {"entity_id": self._source_entity}
+        if percentage is not None:
+            data["percentage"] = percentage
+        await self.hass.services.async_call("fan", "turn_on", data)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the fan off."""
+        await self.hass.services.async_call(
+            "fan", "turn_off", {"entity_id": self._source_entity}
+        )
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the fan speed percentage."""
+        await self.hass.services.async_call(
+            "fan",
+            "set_percentage",
+            {"entity_id": self._source_entity, "percentage": percentage},
+        )
+
+    async def async_update_from_source(self, state) -> None:
+        """Update the entity from the source entity state."""
+        self._attr_is_on = state.state == STATE_ON
+        if (percentage := state.attributes.get("percentage")) is not None:
+            self._attr_percentage = percentage
         self.async_write_ha_state()

--- a/fan.py
+++ b/fan.py
@@ -1,0 +1,37 @@
+"""Platform for fan integration."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DOMAIN,
+    CONF_NAME,
+    CONF_ROTATION_FAN,
+)
+from .entity import HomeKitDeviceFan
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the HomeKit Device fans."""
+    device_type = hass.data[DOMAIN][config_entry.entry_id]["device_type"]
+    base_name = config_entry.data.get(CONF_NAME, "Smart Device")
+    entities = []
+
+    if device_type == "star_projector":
+        if rotation_fan := config_entry.data.get(CONF_ROTATION_FAN):
+            entities.append(
+                HomeKitDeviceFan(
+                    hass,
+                    config_entry.entry_id,
+                    f"{base_name} Rotation",
+                    rotation_fan,
+                )
+            )
+
+    if entities:
+        async_add_entities(entities)

--- a/homekit_type.py
+++ b/homekit_type.py
@@ -1,9 +1,5 @@
 """HomeKit device type definitions."""
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-from homeassistant.components.homekit.const import (
-    SERV_SWITCH,
-    SERV_THERMOSTAT,
-)
 from homeassistant.const import UnitOfTemperature
 
 # HomeKit Categories (from HAP-python)

--- a/homekit_type.py
+++ b/homekit_type.py
@@ -4,7 +4,6 @@ from homeassistant.const import UnitOfTemperature
 
 # HomeKit Categories (from HAP-python)
 CATEGORY_KETTLE = 27
-CATEGORY_FAN = 3
 
 # HomeKit Characteristic UUIDs (from HAP-python)
 CHAR_ON = "00000025-0000-1000-8000-0026BB765291"
@@ -68,106 +67,8 @@ KETTLE_DEVICE_TYPE = {
     ],
 }
 
-# HomeKit Service UUIDs for additional services used by other device types
-SERVICE_LIGHTBULB = "00000043-0000-1000-8000-0026BB765291"
-SERVICE_FANV2 = "000000B7-0000-1000-8000-0026BB765291"
-
-# HomeKit Characteristic UUIDs for additional characteristics
-CHAR_BRIGHTNESS = "00000008-0000-1000-8000-0026BB765291"
-CHAR_HUE = "00000013-0000-1000-8000-0026BB765291"
-CHAR_SATURATION = "0000002F-0000-1000-8000-0026BB765291"
-CHAR_ROTATION_SPEED = "00000029-0000-1000-8000-0026BB765291"
-CHAR_ACTIVE = "000000B0-0000-1000-8000-0026BB765291"
-
-STAR_PROJECTOR_DEVICE_TYPE = {
-    "category": CATEGORY_FAN,
-    "services": [
-        {
-            "name": "Master",
-            "service": SERVICE_SWITCH,
-            "primary": True,
-            "chars": [
-                {
-                    "name": "Power State",
-                    "char": CHAR_ON,
-                    "device_class": BinarySensorDeviceClass.POWER,
-                },
-            ],
-        },
-        {
-            "name": "Rotation",
-            "service": SERVICE_FANV2,
-            "linked": True,
-            "chars": [
-                {
-                    "name": "Active",
-                    "char": CHAR_ACTIVE,
-                },
-                {
-                    "name": "Rotation Speed",
-                    "char": CHAR_ROTATION_SPEED,
-                    "min_value": 0,
-                    "max_value": 100,
-                    "step_value": 1,
-                },
-            ],
-        },
-        {
-            "name": "Laser",
-            "service": SERVICE_LIGHTBULB,
-            "linked": True,
-            "chars": [
-                {
-                    "name": "On",
-                    "char": CHAR_ON,
-                },
-                {
-                    "name": "Brightness",
-                    "char": CHAR_BRIGHTNESS,
-                    "min_value": 0,
-                    "max_value": 100,
-                    "step_value": 1,
-                },
-            ],
-        },
-        {
-            "name": "Background",
-            "service": SERVICE_LIGHTBULB,
-            "linked": True,
-            "chars": [
-                {
-                    "name": "On",
-                    "char": CHAR_ON,
-                },
-                {
-                    "name": "Brightness",
-                    "char": CHAR_BRIGHTNESS,
-                    "min_value": 0,
-                    "max_value": 100,
-                    "step_value": 1,
-                },
-                {
-                    "name": "Hue",
-                    "char": CHAR_HUE,
-                    "min_value": 0,
-                    "max_value": 360,
-                    "step_value": 1,
-                },
-                {
-                    "name": "Saturation",
-                    "char": CHAR_SATURATION,
-                    "min_value": 0,
-                    "max_value": 100,
-                    "step_value": 1,
-                },
-            ],
-        },
-    ],
-}
-
 DEVICE_TYPES = {
     "kettle": KETTLE_DEVICE_TYPE,
-    "star_projector": STAR_PROJECTOR_DEVICE_TYPE,
 }
 
 def get_device_type(device_type: str) -> dict:

--- a/homekit_type.py
+++ b/homekit_type.py
@@ -1,15 +1,15 @@
 """HomeKit device type definitions."""
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.homekit.const import (
     SERV_SWITCH,
     SERV_THERMOSTAT,
 )
-from homeassistant.const import (
-    DEVICE_CLASS_POWER,
-    UnitOfTemperature,
-)
+from homeassistant.const import UnitOfTemperature
 
 # HomeKit Categories (from HAP-python)
 CATEGORY_KETTLE = 27
+CATEGORY_FAN = 3
+CATEGORY_LIGHTBULB = 5
 
 # HomeKit Characteristic UUIDs (from HAP-python)
 CHAR_ON = "00000025-0000-1000-8000-0026BB765291"
@@ -66,7 +66,104 @@ KETTLE_DEVICE_TYPE = {
                 {
                     "name": "Power State",
                     "char": CHAR_ON,
-                    "device_class": DEVICE_CLASS_POWER,
+                    "device_class": BinarySensorDeviceClass.POWER,
+                },
+            ],
+        },
+    ],
+}
+
+# HomeKit Service UUIDs for additional services used by other device types
+SERVICE_LIGHTBULB = "00000043-0000-1000-8000-0026BB765291"
+SERVICE_FANV2 = "000000B7-0000-1000-8000-0026BB765291"
+
+# HomeKit Characteristic UUIDs for additional characteristics
+CHAR_BRIGHTNESS = "00000008-0000-1000-8000-0026BB765291"
+CHAR_HUE = "00000013-0000-1000-8000-0026BB765291"
+CHAR_SATURATION = "0000002F-0000-1000-8000-0026BB765291"
+CHAR_ROTATION_SPEED = "00000029-0000-1000-8000-0026BB765291"
+CHAR_ACTIVE = "000000B0-0000-1000-8000-0026BB765291"
+
+STAR_PROJECTOR_DEVICE_TYPE = {
+    "category": CATEGORY_FAN,
+    "services": [
+        {
+            "name": "Master",
+            "service": SERVICE_SWITCH,
+            "primary": True,
+            "chars": [
+                {
+                    "name": "Power State",
+                    "char": CHAR_ON,
+                    "device_class": BinarySensorDeviceClass.POWER,
+                },
+            ],
+        },
+        {
+            "name": "Rotation",
+            "service": SERVICE_FANV2,
+            "linked": True,
+            "chars": [
+                {
+                    "name": "Active",
+                    "char": CHAR_ACTIVE,
+                },
+                {
+                    "name": "Rotation Speed",
+                    "char": CHAR_ROTATION_SPEED,
+                    "min_value": 0,
+                    "max_value": 100,
+                    "step_value": 1,
+                },
+            ],
+        },
+        {
+            "name": "Laser",
+            "service": SERVICE_LIGHTBULB,
+            "linked": True,
+            "chars": [
+                {
+                    "name": "On",
+                    "char": CHAR_ON,
+                },
+                {
+                    "name": "Brightness",
+                    "char": CHAR_BRIGHTNESS,
+                    "min_value": 0,
+                    "max_value": 100,
+                    "step_value": 1,
+                },
+            ],
+        },
+        {
+            "name": "Background",
+            "service": SERVICE_LIGHTBULB,
+            "linked": True,
+            "chars": [
+                {
+                    "name": "On",
+                    "char": CHAR_ON,
+                },
+                {
+                    "name": "Brightness",
+                    "char": CHAR_BRIGHTNESS,
+                    "min_value": 0,
+                    "max_value": 100,
+                    "step_value": 1,
+                },
+                {
+                    "name": "Hue",
+                    "char": CHAR_HUE,
+                    "min_value": 0,
+                    "max_value": 360,
+                    "step_value": 1,
+                },
+                {
+                    "name": "Saturation",
+                    "char": CHAR_SATURATION,
+                    "min_value": 0,
+                    "max_value": 100,
+                    "step_value": 1,
                 },
             ],
         },
@@ -75,6 +172,7 @@ KETTLE_DEVICE_TYPE = {
 
 DEVICE_TYPES = {
     "kettle": KETTLE_DEVICE_TYPE,
+    "star_projector": STAR_PROJECTOR_DEVICE_TYPE,
 }
 
 def get_device_type(device_type: str) -> dict:

--- a/homekit_type.py
+++ b/homekit_type.py
@@ -5,7 +5,6 @@ from homeassistant.const import UnitOfTemperature
 # HomeKit Categories (from HAP-python)
 CATEGORY_KETTLE = 27
 CATEGORY_FAN = 3
-CATEGORY_LIGHTBULB = 5
 
 # HomeKit Characteristic UUIDs (from HAP-python)
 CHAR_ON = "00000025-0000-1000-8000-0026BB765291"

--- a/light.py
+++ b/light.py
@@ -1,7 +1,7 @@
 """Platform for light integration."""
 from __future__ import annotations
 
-from homeassistant.components.light import LightEntity
+from homeassistant.components.light import ColorMode, LightEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -10,11 +10,31 @@ from .const import (
     DOMAIN,
     CONF_NAME,
     CONF_LIGHT_SWITCH,
+    CONF_LASER_LIGHT,
+    CONF_BACKGROUND_LIGHT,
 )
 from .entity import HomeKitDeviceEntity
 
 class HomeKitDeviceLight(HomeKitDeviceEntity, LightEntity):
     """Representation of a HomeKit Device light."""
+
+    async def async_added_to_hass(self) -> None:
+        """Mirror the source entity's supported color modes once it is known."""
+        modes: set[ColorMode] = {ColorMode.ONOFF}
+        if (state := self.hass.states.get(self._source_entity)) is not None:
+            source_modes = state.attributes.get("supported_color_modes") or ()
+            parsed: set[ColorMode] = set()
+            for raw in source_modes:
+                try:
+                    parsed.add(ColorMode(raw))
+                except ValueError:
+                    continue
+            if parsed:
+                modes = parsed
+        self._attr_supported_color_modes = modes
+        if self._attr_color_mode is None:
+            self._attr_color_mode = next(iter(modes))
+        await super().async_added_to_hass()
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the light on."""
@@ -33,12 +53,20 @@ class HomeKitDeviceLight(HomeKitDeviceEntity, LightEntity):
     async def async_update_from_source(self, state) -> None:
         """Update the entity from the source entity state."""
         self._attr_is_on = state.state == "on"
-        if "brightness" in state.attributes:
-            self._attr_brightness = state.attributes["brightness"]
-        if "color_temp" in state.attributes:
-            self._attr_color_temp = state.attributes["color_temp"]
-        if "rgb_color" in state.attributes:
-            self._attr_rgb_color = state.attributes["rgb_color"]
+        attrs = state.attributes
+        if (brightness := attrs.get("brightness")) is not None:
+            self._attr_brightness = brightness
+        if (kelvin := attrs.get("color_temp_kelvin")) is not None:
+            self._attr_color_temp_kelvin = kelvin
+        if (rgb := attrs.get("rgb_color")) is not None:
+            self._attr_rgb_color = rgb
+        if (hs := attrs.get("hs_color")) is not None:
+            self._attr_hs_color = hs
+        if (raw_mode := attrs.get("color_mode")) is not None:
+            try:
+                self._attr_color_mode = ColorMode(raw_mode)
+            except ValueError:
+                pass
         self.async_write_ha_state()
 
 async def async_setup_entry(
@@ -60,6 +88,26 @@ async def async_setup_entry(
                     config_entry.entry_id,
                     f"{base_name} Light",
                     light_switch,
+                )
+            )
+
+    elif device_type == "star_projector":
+        if laser_light := config_entry.data.get(CONF_LASER_LIGHT):
+            entities.append(
+                HomeKitDeviceLight(
+                    hass,
+                    config_entry.entry_id,
+                    f"{base_name} Laser",
+                    laser_light,
+                )
+            )
+        if background_light := config_entry.data.get(CONF_BACKGROUND_LIGHT):
+            entities.append(
+                HomeKitDeviceLight(
+                    hass,
+                    config_entry.entry_id,
+                    f"{base_name} Background",
+                    background_light,
                 )
             )
 

--- a/light.py
+++ b/light.py
@@ -21,6 +21,7 @@ class HomeKitDeviceLight(HomeKitDeviceEntity, LightEntity):
     async def async_added_to_hass(self) -> None:
         """Mirror the source entity's supported color modes once it is known."""
         modes: set[ColorMode] = {ColorMode.ONOFF}
+        active: ColorMode | None = None
         if (state := self.hass.states.get(self._source_entity)) is not None:
             source_modes = state.attributes.get("supported_color_modes") or ()
             parsed: set[ColorMode] = set()
@@ -31,9 +32,21 @@ class HomeKitDeviceLight(HomeKitDeviceEntity, LightEntity):
                     continue
             if parsed:
                 modes = parsed
+            if (raw_mode := state.attributes.get("color_mode")) is not None:
+                try:
+                    active = ColorMode(raw_mode)
+                except ValueError:
+                    active = None
         self._attr_supported_color_modes = modes
         if self._attr_color_mode is None:
-            self._attr_color_mode = next(iter(modes))
+            # Prefer the source's reported mode; otherwise pick a deterministic
+            # default so HomeKit characteristics don't flap across restarts.
+            if active is not None and active in modes:
+                self._attr_color_mode = active
+            elif ColorMode.ONOFF in modes:
+                self._attr_color_mode = ColorMode.ONOFF
+            else:
+                self._attr_color_mode = sorted(modes, key=lambda m: m.value)[0]
         await super().async_added_to_hass()
 
     async def async_turn_on(self, **kwargs) -> None:

--- a/switch.py
+++ b/switch.py
@@ -14,6 +14,8 @@ from .const import (
     CONF_OSCILLATION,
     CONF_SIREN,
     CONF_KEEP_WARM,
+    CONF_CHILD_LOCK,
+    CONF_DISPLAY_SWITCH,
 )
 from .entity import HomeKitDeviceSwitch
 
@@ -59,6 +61,26 @@ async def async_setup_entry(
                     config_entry.entry_id,
                     f"{base_name} Siren",
                     siren,
+                )
+            )
+
+    elif device_type == "air_purifier":
+        if child_lock := config_entry.data.get(CONF_CHILD_LOCK):
+            entities.append(
+                HomeKitDeviceSwitch(
+                    hass,
+                    config_entry.entry_id,
+                    f"{base_name} Child Lock",
+                    child_lock,
+                )
+            )
+        if display_switch := config_entry.data.get(CONF_DISPLAY_SWITCH):
+            entities.append(
+                HomeKitDeviceSwitch(
+                    hass,
+                    config_entry.entry_id,
+                    f"{base_name} Display",
+                    display_switch,
                 )
             )
 

--- a/translations/en.json
+++ b/translations/en.json
@@ -41,7 +41,12 @@
                     "light_switch": "Light Control",
                     "alarm_state": "Alarm State Control",
                     "sensors": "Security Sensors",
-                    "siren": "Siren Control"
+                    "siren": "Siren Control",
+                    "laser_light": "Laser Light",
+                    "background_light": "Background/Nebula Light",
+                    "rotation_fan": "Rotation Fan",
+                    "child_lock": "Child Lock Switch",
+                    "display_switch": "Display On/Off Switch"
                 }
             }
         },
@@ -66,7 +71,8 @@
                 "humidifier": "Smart Humidifier",
                 "air_purifier": "Air Purifier",
                 "garage_door": "Garage Door",
-                "security_system": "Security System"
+                "security_system": "Security System",
+                "star_projector": "Star Projector"
             }
         }
     },
@@ -78,7 +84,8 @@
         "humidifier": "Combines humidity sensing and control into a smart humidifier",
         "air_purifier": "Creates an air purifier with air quality monitoring",
         "garage_door": "Combines door controls and sensors into a garage door opener",
-        "security_system": "Creates a security system from multiple sensors and controls"
+        "security_system": "Creates a security system from multiple sensors and controls",
+        "star_projector": "Combines a master switch, rotation fan and laser/background lights into a single star projector device"
     },
     "entity_descriptions": {
         "power_switch": "Main power control for the device",
@@ -103,12 +110,17 @@
         "filter_life": "Monitors the air filter's remaining life",
         "pm25": "Shows the PM2.5 particulate matter level",
         "voc": "Shows the Volatile Organic Compounds level",
+        "child_lock": "Switch that locks/unlocks the device's physical controls",
+        "display_switch": "Switch that turns the device's display on or off",
         "door_position": "Controls and monitors the door position",
         "obstruction": "Detects obstructions in the door's path",
         "motion": "Detects motion near the door",
         "light_switch": "Controls the associated light",
         "alarm_state": "Controls the security system's state",
         "sensors": "Security sensors to monitor",
-        "siren": "Controls the security system's siren"
+        "siren": "Controls the security system's siren",
+        "laser_light": "Star/laser projection light with brightness control",
+        "background_light": "Nebula/background light with brightness and colour control",
+        "rotation_fan": "Fan entity that controls rotation speed of the projection"
     }
 }


### PR DESCRIPTION
Adds two new device-type configurations and brings the integration up to date with current Home Assistant APIs.

## New device type: star_projector

- Aggregates a master switch, rotation fan, and laser/background lights into a single HomeKit accessory.
- Adds a fan platform (fan.py) and a HomeKitDeviceFan wrapper that forwards turn_on/turn_off/set_percentage to the source fan entity.

## Air purifier extension

- Adds optional child_lock and display_switch slots to the air_purifier device type, exposed as additional HomeKitDeviceSwitch wrappers.

## Home Assistant 2026.x compatibility

- homekit_type.py: replace removed DEVICE_CLASS_POWER (gone from homeassistant.const) with BinarySensorDeviceClass.POWER from homeassistant.components.binary_sensor.
- entity.py: migrate from deprecated async_track_state_change to async_track_state_change_event, with the modern Event[EventStateChangedData] callback signature.
- light.py: HomeKitDeviceLight now uses _attr_color_temp_kelvin (the previous _attr_color_temp has been removed from LightEntity), forwards hs_color and color_mode, and declares supported_color_modes from the source on async_added_to_hass so HomeKit Bridge sees the correct light characteristics.

Resolves #1
Resolves #2
Resolves #3

---

## Copilot summary

This pull request adds support for a new "star projector" device type, enhances the air purifier device with additional switch controls, and introduces fan entity support. It updates the configuration, entities, and HomeKit type definitions to enable seamless integration of these new features, especially for devices that combine lights and fans (like child night lights). The most important changes are grouped below:

**New device type: Star Projector**

* Added a new "star_projector" device type, including HomeKit type definitions, configuration schema, and documentation. This device supports a master switch, rotation fan, laser light, and background/nebula light, allowing aggregation of multiple entities into one HomeKit accessory. [[1]](diffhunk://#diff-4562f004f3b3afb4803b5d2a48f36f10d466733015b76195b5f00d57fa330c72L43-R44) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R176) [[3]](diffhunk://#diff-942e2b26acccf15613a9fb87dc157656c0b23ec384c78d47067d137f1bf87610R175) [[4]](diffhunk://#diff-f9e42b63bfee19d19ea186604dc163e839e8faa2c59d9ec8fc6884c31f98aa7fR234-R244) [[5]](diffhunk://#diff-6fca8a289be2fa658792936fc459e6e36e6fa56d9187da43c01ec491f9f8a6b5L69-R75)

**Fan entity/platform support**

* Introduced a new `fan.py` platform, with the `HomeKitDeviceFan` entity class to represent and control fan devices (e.g., the star projector's rotation fan), and registered the platform for use in the integration. [[1]](diffhunk://#diff-8e2c1f727276d30ced72fa67cb848772a9802162bec39b42a8df5359fd063a4cR24) [[2]](diffhunk://#diff-c4f9dc5ef6603f37cf026ccad232d097aa06831e2c0488e1d502f01a92cc56a5R7-R18) [[3]](diffhunk://#diff-c4f9dc5ef6603f37cf026ccad232d097aa06831e2c0488e1d502f01a92cc56a5R156-R197) [[4]](diffhunk://#diff-f81efb969b5fcdd4d2e256c1698433e68971e9a3f47d0c7243e23b00467fdceaR1-R37)

**Air purifier enhancements**

* Added support for optional "Child Lock Switch" and "Display On/Off Switch" controls for the air purifier device type, updating configuration, entity setup, and documentation accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R138) [[2]](diffhunk://#diff-4562f004f3b3afb4803b5d2a48f36f10d466733015b76195b5f00d57fa330c72R83-R84) [[3]](diffhunk://#diff-f9e42b63bfee19d19ea186604dc163e839e8faa2c59d9ec8fc6884c31f98aa7fR44-R48) [[4]](diffhunk://#diff-f9e42b63bfee19d19ea186604dc163e839e8faa2c59d9ec8fc6884c31f98aa7fR199-R204) [[5]](diffhunk://#diff-0608a06ca9491338617d3147bdaa769d51c7d5a05e7c8ffa75df534a4c39bf48R67-R86) [[6]](diffhunk://#diff-6fca8a289be2fa658792936fc459e6e36e6fa56d9187da43c01ec491f9f8a6b5L44-R49)

**Light entity improvements**

* Improved the `HomeKitDeviceLight` entity to better mirror the source entity's color modes and attributes, and added support for the star projector's laser and background lights in the light platform. [[1]](diffhunk://#diff-048707378b1c49f5caddc1ece563f5f3c580638dc381b2d6f8ea3bdfc030e0ddL4-R4) [[2]](diffhunk://#diff-048707378b1c49f5caddc1ece563f5f3c580638dc381b2d6f8ea3bdfc030e0ddR13-R38) [[3]](diffhunk://#diff-048707378b1c49f5caddc1ece563f5f3c580638dc381b2d6f8ea3bdfc030e0ddL36-R69) [[4]](diffhunk://#diff-048707378b1c49f5caddc1ece563f5f3c580638dc381b2d6f8ea3bdfc030e0ddR94-R113)

**HomeKit type and translation updates**

* Extended HomeKit type definitions with new service and characteristic UUIDs for lights and fans, and updated English translations to cover new entity and device types. (F85b1eedL14R14, [[1]](diffhunk://#diff-942e2b26acccf15613a9fb87dc157656c0b23ec384c78d47067d137f1bf87610L69-R166) [[2]](diffhunk://#diff-6fca8a289be2fa658792936fc459e6e36e6fa56d9187da43c01ec491f9f8a6b5L44-R49) [[3]](diffhunk://#diff-6fca8a289be2fa658792936fc459e6e36e6fa56d9187da43c01ec491f9f8a6b5L69-R75)